### PR TITLE
CH8: extract BottleVerse class and remove Law of Demeter and DIP viol…

### DIFF
--- a/src/bottles/bottles.py
+++ b/src/bottles/bottles.py
@@ -1,18 +1,4 @@
-class Bottle:
-    def song(self) -> str:
-        return self.verses(99, 0)
-
-    def verses(self, upper: int, lower: int) -> str:
-        return "\n".join(
-            [self.verse(i) for i in reversed(range(lower, upper + 1))]
-        )
-
-    def verse(self, number: int) -> str:
-        bn = BottleNumber.get(number)
-        return (
-            f"{bn.to_str().capitalize()} of beer on the wall, {bn.to_str()} of beer.\n"
-            f"{bn.action()}, {bn.successor().to_str()} of beer on the wall.\n"
-        )
+from typing import Protocol, Type
 
 
 class BottleNumber:
@@ -75,3 +61,48 @@ class BottleNumber6(BottleNumber):
 
     def container(self) -> str:
         return "six-pack"
+
+
+class VerseTemplate(Protocol):
+    def __init__(self, bottle_number) -> None:
+        pass
+
+    @staticmethod
+    def lyrics(number: int) -> str:
+        pass
+
+    def _lyrics(self) -> str:
+        pass
+
+
+class BottleVerse:
+    def __init__(self, bottle_number) -> None:
+        self.bottle_number = bottle_number
+
+    @staticmethod
+    def lyrics(number: int):
+        return BottleVerse(BottleNumber.get(number))._lyrics()
+
+    def _lyrics(self) -> str:
+        return (
+            f"{self.bottle_number.to_str().capitalize()} of beer on the wall, {self.bottle_number.to_str()} of beer.\n"
+            f"{self.bottle_number.action()}, {self.bottle_number.successor().to_str()} of beer on the wall.\n"
+        )
+
+
+class Bottle:
+    def __init__(
+        self, verse_template: Type[VerseTemplate] = BottleVerse
+    ) -> None:
+        self.verse_template = verse_template
+
+    def song(self) -> str:
+        return self.verses(99, 0)
+
+    def verses(self, upper: int, lower: int) -> str:
+        return "\n".join(
+            [self.verse(i) for i in reversed(range(lower, upper + 1))]
+        )
+
+    def verse(self, number: int) -> str:
+        return self.verse_template.lyrics(number)


### PR DESCRIPTION
We are extracting a new class, `BottleVerse`, to reduce the responsibilities of `Bottle`. `BottleVerse` will hold the logic regarding what verse should be played, given the verse number.

We leverage `typing.Protocol` to define the contract every `VerseTemplates` should respect. `BottleVerse` is currently the only class implementing such protocol. `Protocol`s allow you to avoid [inheritance](https://en.wikipedia.org/wiki/Inheritance_(object-oriented_programming)). If you're interested in learning more about `Protocol` and Inheritance, [here](https://jarombek.com/blog/dec-15-2018-python-protocols-abcs) is a good article for you to read.

As the `BottleVerse` class is now responsible for returning the lyrics, we have eliminated any coupling between `Bottle` and `BottleNumber`. We now inject a `VerseTemplate` dependency to `Bottle` at construction time, making the latter more _open for extension, but closed for modification_<sup>1</sup>. `Bottle` still relies on the direct collaborator's API ― since there is a call to [`self.verse_template.lyrics(number)`](https://github.com/IamGianluca/99bottles/pull/7/files#diff-1ed58904f1458d68836195ecdfb6c76465dcea0e1ac98dc97e4fa59a2b5abee0R108), but it depends on an abstraction.

### Subtleties about the Law of Demeter

Something interesting... the only "public"<sup>2</sup> method in `BottleVerse`, `lyrics()`, is a static method. This method, however, internally calls a non-static method, `_lyrics()`. 

```python
class BottleVerse:
    def __init__(self, bottle_number) -> None:
        self.bottle_number = bottle_number

    @staticmethod
    def lyrics(number: int):
        return BottleVerse(BottleNumber.get(number))._lyrics()

    def _lyrics(self) -> str:
        return (
            f"{self.bottle_number.to_str().capitalize()} of beer on the wall, {self.bottle_number.to_str()} of beer.\n"
            f"{self.bottle_number.action()}, {self.bottle_number.successor().to_str()} of beer on the wall.\n"
        )
```

I've never encountered this pattern before, and I must admit I was left a little puzzled at the beginning. Why are the authors recommending it?

Let's take a step back and figure out what is the issue with the following code snippet:

```python
class Bottle:
    def __init__(self, verse_template: Type[VerseTemplate]):
        self.verse_template = verse_template

    def verse(self, number: int) -> str:
        return self.verse_template(number).lyrics()
```

`Bottle.verse()` is calling the `__init__()` magic method on `self.verse_template`, a dependency we injected at construction time, and then calls the `lyrics()` method on the returned class instance. 

At first sight, the code above doesn't seem a violation of the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter). After all, we are simply calling two methods on a direct collaborator of `Bottle`. Sandi, however, makes a brilliant point, which is critical to understand the Law of Demeter fully:

> It is not the number of dots that matter but the kind of objects returned by each message.

Now, here is the catch. `Bottle` needs to know quite a few things about its collaborator. Namely, that:

* To construct an instance of the direct collaborator, we need to pass an argument, `number`
* Such argument, `number`, is an `int`
* This direct collaborator has a method named `lyrics()`
* Such method doesn't take any argument

Those are a lot of dependencies, and dependencies are something we want to reduce in good OOP. 

The following code snippet removes two of the four things `Bottle` needs to know about its collaborator:

```python
class Bottle:
    def __init__(self, verse_template: Type[VerseTemplate]):
        self.verse_template = verse_template

    def verse(self, number: int) -> str:
        return self.verse_template.lyrics(number)
```

Now, `Bottle` only needs to know that:

* This direct collaborator has a method named `lyrics()`
* Such method doesn't take any argument

Fixing this code smell helps decouple the two objects, reducing future problems if the `VerseTemplate`'s API changes.



Footnotes:

* [<sup>1</sup>]: See [Open-Closed Principle](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle).
* [<sup>2</sup>]: There is technically no such thing as a true private method in Python. Everything is public, but the leading `_` in the method's name hints from the original author that the method should not be used outside of the class. 